### PR TITLE
Don't count reviews/comments on own PRs

### DIFF
--- a/backend/pkg/leader/config.go
+++ b/backend/pkg/leader/config.go
@@ -11,6 +11,7 @@ import (
 // Config returns configuration for retrieving data via GitHub API (query)
 // and building aggregated Chart Data
 func Config() (Configuration, error) {
+	//nolint:godox
 	// TODO(juliaogris): Read from config file and/or command line
 	initialCursor := ""
 	createdAfter, _ := time.Parse(time.RFC3339, "2019-05-15T00:00:00Z")

--- a/backend/pkg/leader/types.go
+++ b/backend/pkg/leader/types.go
@@ -136,7 +136,11 @@ func ChartDataFromPRs(gqlPRs []PRNode, config ChartDataConfig) ChartData {
 			countByAuthor.open[author]++
 		}
 		for _, review := range pr.Reviews.ReviewNodes {
+			// Don't count reviews on own PRs. These occur when you respond to comments.
 			author := review.Author.Login
+			if author == pr.Author.Login {
+				continue
+			}
 			authors[author] = review.Author
 			countByAuthor.review[author]++
 			// Add 1 to comment count because the review itself must contain a "comment" which isn't counted.

--- a/backend/pkg/leader/types.go
+++ b/backend/pkg/leader/types.go
@@ -1,3 +1,6 @@
+// Package leader produces a leaderboard summary from a github repository's
+// pull requests as a JSON file. This file can be loaded by the react frontend
+// to display the summary.
 package leader
 
 import (

--- a/backend/pkg/leader/types_test.go
+++ b/backend/pkg/leader/types_test.go
@@ -161,6 +161,14 @@ const prResultFixture = `{
                     "avatarUrl": "https://avatars3.githubusercontent.com/u/215143?v=4"
                   },
                   "comments": { "totalCount": 5 }
+                },
+                {
+                  "author": {
+                    "login": "kasunfdo",
+                    "url": "https://github.com/kasunfdo",
+		    "avatarUrl": "https://avatars3.githubusercontent.com/u/12541716?v=4"
+                  },
+                  "comments": { "totalCount": 5 }
                 }
               ]
             },

--- a/backend/pkg/leader/types_test.go
+++ b/backend/pkg/leader/types_test.go
@@ -17,7 +17,7 @@ func TestTypes(t *testing.T) {
 	assert.JSONEq(t, prResultFixture, string(jsonStr))
 }
 
-func TestChartDataFromGQL(t *testing.T) {
+func TestChartDataFromGQL(t *testing.T) { //nolint:funlen
 	gql := graphQLdata{}
 	assert.NoError(t, json.Unmarshal([]byte(prResultFixture), &gql))
 	prs := gql.Data.Repository.PullRequests.PRNodes

--- a/gcloudfunction.go
+++ b/gcloudfunction.go
@@ -1,3 +1,5 @@
+// Package gcloudfunc contains the Google Cloud Function to generate the
+// leaderboard stats when triggered by a webhook.
 package gcloudfunc
 
 import (
@@ -83,11 +85,11 @@ func writeBucket(r io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("writeBucket: cannot create bucket client: %s", err)
 	}
-	defer client.Close()
+	defer client.Close() //nolint:errcheck
 	bucket := client.Bucket(bucketName)
 	object := bucket.Object(objectName)
 	w := object.NewWriter(ctx)
-	defer w.Close()
+	defer w.Close() //nolint:errcheck
 	if _, err := io.Copy(w, r); err != nil {
 		return fmt.Errorf("writeBucket: cannot copy reader to bucket: %s", err)
 	}


### PR DESCRIPTION
The count of reviews and comments was including an author's comments on
their own PRs. These occur when they respond to comments. A response can
be done as a single published review, or comment-by-comment. In the
latter case, each comment is counted as a separate review. This can
massively inflate the numbers for peoples responses to reviews on their
PRs and is unfavourable to those with no PRs or few comments on their
PRs.

Update the tests to add the case of self-comments on a PR to ensure they
are not counted.

This affects the leaderboard quite significantly, after the change, the top 10 reviews and comments:
```
Reviews:
        { "author": "juliaogris", "count": 225 },
        { "author": "camh-anz", "count": 106 },
        { "author": "rokane", "count": 88 },
        { "author": "anzboi", "count": 72 },
        { "author": "n0npax", "count": 72 },
        { "author": "pentaphobe", "count": 44 },
        { "author": "alfredxiao", "count": 33 },
        { "author": "kasunfdo", "count": 29 },
        { "author": "nicholascross", "count": 29 },
        { "author": "willshen8", "count": 27 },
 
Comments:
        { "author": "juliaogris", "count": 753 },
        { "author": "camh-anz", "count": 453 },
        { "author": "rokane", "count": 262 },
        { "author": "anzboi", "count": 235 },
        { "author": "n0npax", "count": 175 },
        { "author": "willshen8", "count": 96 },
        { "author": "anzdaddy", "count": 77 },
        { "author": "kasunfdo", "count": 73 },
        { "author": "Joshcarp", "count": 72 },
        { "author": "marksomething", "count": 66 },
 ```
