### PR TITLE
graphql: Change limits to get almost all reviews/comments

### DIFF
--- a/backend/pkg/leader/graphql.go
+++ b/backend/pkg/leader/graphql.go
@@ -40,14 +40,14 @@ const gqlFragment = `{
           url
           avatarUrl
         }
-        reviews(first: 20) {
+        reviews(first: 100) {
           nodes {
             author {
               login
               url
               avatarUrl
             }
-            comments(first: 60) {
+            comments {
               totalCount
             }
           }


### PR DESCRIPTION
Some reviews and comments are not being counted because of the limits
used for them - there are more than 20 reviews for some PRs, but we are
only retrieving the first 20.

Increase the number of reviews to the max of 100. Also remove the limit
on the comments in the reviews because we do not actually retrieve the
comments, just the totalCount. This should reduce the cost of the query
quite a bit - if we didn't do this, the total nodes in the query would
be large (60x) and we could not do this query without reducing the
number of PRs returned each time.

There is one PR with 107 reviews - we're not properly counting that. We
cannot do that without restructuring the code to query reviews directly
and use a cursor. That's more than I want to do right now.