### PR TITLE
Update linter configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coverage.out

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,4 +3,5 @@ issues:
 linters:
   enable-all: true
   disable:
-    gochecknoglobals
+  - gochecknoglobals
+  - wsl


### PR DESCRIPTION
`wsl` is a new default linter of golangci which produces many (imo
unreasonable) error messages. Disable by default.